### PR TITLE
fix dependency issue with numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ networkx>=2.5
 plotly>=4.14.3
 scipy>=1.1.0
 scot==0.2.1
+numba~=0.56.0
 antropy>=0.1.4
 kaleido==0.2.1


### PR DESCRIPTION
### Fixes a dependency issue with numba

### In Detail:
The required package _antropy_ needs numba installed. Latest _numba_ version (0.58.0) does not support numpy 1.21.1. **This fix sets the numba version to a compatible version (0.56.x).**